### PR TITLE
add RH UBI based build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ internal/core/src/pb/*.pb.h
 internal/core/src/pb/*.pb.cc
 *.pb.go
 **/legacypb/*.pb.go
+
+# podman volumes
+**/volumes/**

--- a/build/build_multi_stage.sh
+++ b/build/build_multi_stage.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 DOCKERFILE="${DOCKERFILE:-./build/multi-stage/cpu/ubi-rhel/Dockerfile}"
 IMAGE_ARCH="${IMAGE_ARCH:-amd64}"
 MILVUS_IMAGE_REPO="${MILVUS_IMAGE_REPO:-quay.io/redhat-et/milvus}"
-MILVUS_IMAGE_TAG="${MILVUS_IMAGE_TAG:-standalone-rhel94}"
+MILVUS_IMAGE_TAG="${MILVUS_IMAGE_TAG:-standalone-rhel9.5}"
 CONTAINER_CMD="${CONTAINER_CMD:-podman}"
 
 # RH distros package repos use x86_64 rather than amd64, and aarch64 rather than arm64

--- a/build/build_multi_stage.sh
+++ b/build/build_multi_stage.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Licensed to the LF AI & Data foundation under one
+# or more contributor license agreements. See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership. The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+DOCKERFILE="${DOCKERFILE:-./build/multi-stage/cpu/ubi-rhel/Dockerfile}"
+IMAGE_ARCH="${IMAGE_ARCH:-amd64}"
+MILVUS_IMAGE_REPO="${MILVUS_IMAGE_REPO:-quay.io/redhat-et/milvus}"
+MILVUS_IMAGE_TAG="${MILVUS_IMAGE_TAG:-standalone-rhel94}"
+CONTAINER_CMD="${CONTAINER_CMD:-podman}"
+
+# RH distros package repos use x86_64 rather than amd64, and aarch64 rather than arm64
+RH_TARGETARCH="${RH_TARGETARCH:-x86_64}"
+
+if [ -z "$IMAGE_ARCH" ]; then
+    MACHINE=$(uname -m)
+    if [ "$MACHINE" = "x86_64" ]; then
+        IMAGE_ARCH="amd64"
+        RH_TARGETARCH="x86_64"
+    else
+        IMAGE_ARCH="arm64"
+        RH_TARGETARCH="aarch64"
+    fi
+fi
+
+echo ${IMAGE_ARCH}
+
+BUILD_ARGS="${BUILD_ARGS:---build-arg TARGETARCH=${IMAGE_ARCH} --build-arg RH_TARGETARCH=${RH_TARGETARCH}}"
+
+${CONTAINER_CMD} build --network host ${BUILD_ARGS} --platform linux/${IMAGE_ARCH} -f "${DOCKERFILE}" -t "${MILVUS_IMAGE_REPO}:${MILVUS_IMAGE_TAG}" .

--- a/build/multi-stage/cpu/ubi-rhel/Dockerfile
+++ b/build/multi-stage/cpu/ubi-rhel/Dockerfile
@@ -1,0 +1,145 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.4-947.1717074712 as vcpkg-installer
+
+RUN dnf install -y wget zip git gcc gcc-c++ cmake \
+        dnf-plugins-core ninja-build \
+        perl-IPC-Cmd perl-Digest-SHA \
+        perl-FindBin perl-File-Compare perl-File-Copy 
+
+ENV VCPKG_FORCE_SYSTEM_BINARIES 1
+
+RUN mkdir /opt/vcpkg &&  \
+    wget -qO- vcpkg.tar.gz https://github.com/microsoft/vcpkg/archive/refs/tags/2023.11.20.tar.gz | tar --strip-components=1 -xz -C /opt/vcpkg && \
+    rm -rf vcpkg.tar.gz
+
+# empty the vscpkg toolchains linux.cmake file to avoid the error
+RUN echo "" > /opt/vcpkg/scripts/toolchains/linux.cmake
+
+# install azure-identity-cpp azure-storage-blobs-cpp gtest via vcpkg
+RUN /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics && \
+    ln -s /opt/vcpkg/vcpkg /usr/local/bin/vcpkg && \
+    vcpkg version && \
+    vcpkg install azure-identity-cpp azure-storage-blobs-cpp gtest
+
+
+#FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubi9
+FROM registry.access.redhat.com/ubi9/ubi:9.4-947.1717074712 as builder
+
+ARG RH_TARGETARCH
+ARG TARGETARCH
+
+RUN dnf update -y && dnf install -y \
+        https://www.rpmfind.net/linux/centos-stream/9-stream/AppStream/$RH_TARGETARCH/os/Packages/perl-Unicode-EastAsianWidth-12.0-7.el9.noarch.rpm \
+        https://www.rpmfind.net/linux/centos-stream/9-stream/AppStream/$RH_TARGETARCH/os/Packages/perl-Text-Unidecode-1.30-16.el9.noarch.rpm \
+        https://www.rpmfind.net/linux/centos-stream/9-stream/AppStream/$RH_TARGETARCH/os/Packages/perl-libintl-perl-1.32-4.el9.$RH_TARGETARCH.rpm \
+        https://www.rpmfind.net/linux/centos-stream/9-stream/CRB/$RH_TARGETARCH/os/Packages/texinfo-6.7-15.el9.$RH_TARGETARCH.rpm \
+        https://www.rpmfind.net/linux/centos-stream/9-stream/AppStream/$RH_TARGETARCH/os/Packages/libaio-devel-0.3.111-13.el9.$RH_TARGETARCH.rpm \
+        https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+
+RUN dnf install -y \
+    git \
+    gcc \
+    gcc-c++ \
+    glibc-devel \
+    gdb \
+    make \
+    #cmake \
+    automake \
+    libffi-devel \
+    libtool \
+    pkgconfig \
+    wget \
+    unzip \
+    tar \
+    bzip2 \
+    openssl-devel \
+    libaio \
+    libstdc++-static \
+    llvm-toolset \
+    ninja-build \
+    openblas \
+    openblas-devel \
+    zip unzip \
+    zlib-devel \
+    libcurl-devel \
+    libuuid-devel \
+    perl-IPC-Cmd perl-Digest-SHA perl-FindBin \
+    python3-pip && \
+    pip3 install --upgrade pip && \
+    pip3 install conan==1.64.1 && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+# Install cmake version 3.27, upstream uses this version, and the 'dnf install cmake' version fails
+RUN wget -qO- "https://cmake.org/files/v3.27/cmake-3.27.5-linux-`uname -m`.tar.gz" | tar --strip-components=1 -xz -C /usr/local
+
+WORKDIR /home/milvus
+
+# TODO: switch to main branch
+RUN git clone --depth 1 --branch rh-build https://github.com/sallyom/milvus.git . \
+    && rm -rf .git
+
+COPY --chown=1001:1001 build/docker/builder/entrypoint.sh /home/milvus/
+
+COPY --from=vcpkg-installer /root/.cache/vcpkg /home/milvus/.cache/vcpkg
+
+# Install go
+RUN mkdir -p /usr/local/go && wget -qO- "https://go.dev/dl/go1.23.3.linux-$TARGETARCH.tar.gz" | tar --strip-components=1 -xz -C /usr/local/go
+ENV PATH=$PATH:/usr/local/go/bin
+
+# Install rust
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain=1.73 -y
+ENV PATH=/home/milvus/.cargo/bin:/usr/local/bin:/usr/local/go/bin:$PATH
+
+# Option - Add Include Path instead of symlinks below?
+#ENV CMAKE_INCLUDE_PATH=/usr/include/openblas:$CMAKE_INCLUDE_PATH
+RUN for file in /usr/include/openblas/*; do \
+      ln -s "$file" /usr/include/"$(basename "$file")"; \
+    done
+
+ENV HOME=/home/milvus
+RUN useradd -m milvus && mkdir -p /home/milvus/conan && chown -R milvus:milvus /home/milvus
+RUN chown -R milvus:milvus /home/milvus
+USER milvus
+RUN /home/milvus/entrypoint.sh
+
+# configs are for standalone with embedded ETCD
+RUN cp /home/milvus/build/multi-stage/cpu/ubi-rhel/configs/* /home/milvus/configs/.
+
+ENV CONAN_USER_HOME=/home/milvus/conan
+RUN make install
+
+FROM registry.access.redhat.com/ubi9/ubi:9.4-947.1717074712
+
+ARG TARGETARCH
+ARG RH_TARGETARCH
+
+RUN dnf update -y && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN dnf install -y \
+    https://www.rpmfind.net/linux/centos-stream/9-stream/AppStream/$RH_TARGETARCH/os/Packages/libaio-devel-0.3.111-13.el9.$RH_TARGETARCH.rpm \
+    ca-certificates \
+    libaio \
+    libgomp \
+    openblas \
+    openblas-devel && \
+    dnf clean all && \
+    rm -rf /var/cache/dnf
+
+WORKDIR /milvus
+
+RUN curl -L -o /milvus/tini https://github.com/krallin/tini/releases/download/v0.19.0/tini-$TARGETARCH && \
+    chmod +x /milvus/tini
+
+COPY --chmod=774 --from=builder /home/milvus/bin/ /milvus/bin/
+COPY --chmod=774 --from=builder /home/milvus/configs/ /milvus/configs/
+COPY --chmod=774 --from=builder /home/milvus/lib/ /milvus/lib/
+
+ENV PATH=/milvus/bin:$PATH
+ENV LD_LIBRARY_PATH=/milvus/lib:$LD_LIBRARY_PATH:/usr/lib
+ENV LD_PRELOAD=/milvus/lib/libjemalloc.so
+ENV MALLOC_CONF=background_thread:true
+ENV ETCD_USE_EMBED=true
+ENV ETCD_CONFIG_PATH=/milvus/configs/embedEtcd.yaml
+ENV COMMON_STORAGETYPE=local
+
+ENTRYPOINT ["/milvus/tini", "--"]

--- a/build/multi-stage/cpu/ubi-rhel/Dockerfile
+++ b/build/multi-stage/cpu/ubi-rhel/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.4-947.1717074712 as vcpkg-installer
+FROM registry.access.redhat.com/ubi9:9.5-1732804088 as vcpkg-installer
 
 RUN dnf install -y wget zip git gcc gcc-c++ cmake \
         dnf-plugins-core ninja-build \
@@ -22,7 +22,7 @@ RUN /opt/vcpkg/bootstrap-vcpkg.sh -disableMetrics && \
 
 
 #FROM nvcr.io/nvidia/cuda:12.4.1-devel-ubi9
-FROM registry.access.redhat.com/ubi9/ubi:9.4-947.1717074712 as builder
+FROM registry.access.redhat.com/ubi9:9.5-1732804088 as builder
 
 ARG RH_TARGETARCH
 ARG TARGETARCH
@@ -109,7 +109,7 @@ RUN cp /home/milvus/build/multi-stage/cpu/ubi-rhel/configs/* /home/milvus/config
 ENV CONAN_USER_HOME=/home/milvus/conan
 RUN make install
 
-FROM registry.access.redhat.com/ubi9/ubi:9.4-947.1717074712
+FROM registry.access.redhat.com/ubi9:9.5-1732804088
 
 ARG TARGETARCH
 ARG RH_TARGETARCH

--- a/build/multi-stage/cpu/ubi-rhel/README.md
+++ b/build/multi-stage/cpu/ubi-rhel/README.md
@@ -49,3 +49,7 @@ podman run --rm -d \
     quay.io/redhat-et/milvus:standalone-rhel94 \
     milvus run standalone
 ```
+
+### Run RAG application with milvus
+
+Follow [this example](../../../deployments/podman-kube-play/README.md) to deploy a local RAG application with standalone Milvus.

--- a/build/multi-stage/cpu/ubi-rhel/README.md
+++ b/build/multi-stage/cpu/ubi-rhel/README.md
@@ -1,0 +1,51 @@
+## HOW TO BUILD
+
+### Build Milvus image
+
+The following environment variables can be set for the build, shown here with defaults:
+
+```
+MILVUS_IMAGE_REPO="${MILVUS_IMAGE_REPO:-quay.io/redhat-et/milvus}"
+MILVUS_IMAGE_TAG="${MILVUS_IMAGE_TAG:-standalone-rhel94}"
+IMAGE_ARCH="${IMAGE_ARCH:-amd64}"
+RH_TARGETARCH="${RH_TARGETARCH:-x86_64}"
+BUILD_ARGS="${BUILD_ARGS:---build-arg TARGETARCH=${IMAGE_ARCH} --build-arg RH_TARGETARCH=${RH_TARGETARCH}}"
+```
+
+Run the following from the root of the repository.
+
+```bash
+./build/build_multi_stage.sh
+```
+
+The build takes a long time depending on your system, ~1hr
+
+## HOW TO RUN
+
+### Run standalone milvus service
+
+Create the milvus data volume
+
+```bash
+mkdir -p /tmp/volumes/milvus
+```
+
+Run milvus standalone
+
+```bash
+podman run --rm -d \
+    --name milvus-standalone \
+    --security-opt seccomp:unconfined \
+    -v /tmp/volumes/milvus:/var/lib/milvus:Z  \
+    -p 19530:19530 \
+    -p 9091:9091 \
+    -p 2379:2379 \
+    -e ETCD_DATA_DIR=/var/lib/milvus/etcd \
+    --health-cmd="curl -f http://localhost:9091/healthz" \
+    --health-interval=30s \
+    --health-start-period=90s \
+    --health-timeout=20s \
+    --health-retries=3 \
+    quay.io/redhat-et/milvus:standalone-rhel94 \
+    milvus run standalone
+```

--- a/build/multi-stage/cpu/ubi-rhel/README.md
+++ b/build/multi-stage/cpu/ubi-rhel/README.md
@@ -6,7 +6,7 @@ The following environment variables can be set for the build, shown here with de
 
 ```
 MILVUS_IMAGE_REPO="${MILVUS_IMAGE_REPO:-quay.io/redhat-et/milvus}"
-MILVUS_IMAGE_TAG="${MILVUS_IMAGE_TAG:-standalone-rhel94}"
+MILVUS_IMAGE_TAG="${MILVUS_IMAGE_TAG:-standalone-rhel9.5}"
 IMAGE_ARCH="${IMAGE_ARCH:-amd64}"
 RH_TARGETARCH="${RH_TARGETARCH:-x86_64}"
 BUILD_ARGS="${BUILD_ARGS:---build-arg TARGETARCH=${IMAGE_ARCH} --build-arg RH_TARGETARCH=${RH_TARGETARCH}}"
@@ -46,7 +46,7 @@ podman run --rm -d \
     --health-start-period=90s \
     --health-timeout=20s \
     --health-retries=3 \
-    quay.io/redhat-et/milvus:standalone-rhel94 \
+    quay.io/redhat-et/milvus:standalone-rhel9.5 \
     milvus run standalone
 ```
 

--- a/build/multi-stage/cpu/ubi-rhel/configs/embedEtcd.yaml
+++ b/build/multi-stage/cpu/ubi-rhel/configs/embedEtcd.yaml
@@ -1,0 +1,5 @@
+listen-client-urls: http://0.0.0.0:2379
+advertise-client-urls: http://0.0.0.0:2379
+quota-backend-bytes: 4294967296
+auto-compaction-mode: revision
+auto-compaction-retention: '1000'

--- a/build/multi-stage/cpu/ubi-rhel/configs/user.yaml
+++ b/build/multi-stage/cpu/ubi-rhel/configs/user.yaml
@@ -1,0 +1,1 @@
+# Extra config to override default milvus.yaml

--- a/deployments/podman-kube-play/README.md
+++ b/deployments/podman-kube-play/README.md
@@ -1,0 +1,38 @@
+## Example RAG application with standalone Milvus
+
+This assumes you have a local model-server running and the MODEL_ENDPOINT is `http://127.0.0.1:8001`. Adjust [rag-milvus-ex.yaml](./rag-milvus-ex.yaml) as necessary,
+according to your environment.
+
+For an example of a simple llamacpp model-server,
+see [github.com/containers/ai-lab-recipes](https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python#deploy-model-service).
+
+### Deploy RAG application
+
+Create the milvus data volume on the local file system.
+
+```bash
+mkdir -p /tmp/volumes/milvus
+```
+
+Run podman rag-milvus pod
+
+```bash
+podman kube play ./rag-milvus-ex.yaml
+```
+
+### Interact with RAG application
+
+Visit local browser at `http://localhost:8501`
+
+### View pod logs
+
+```bash
+podman pod list
+podman pod logs rag-app-milvus
+```
+
+### Stop RAG application
+
+```bash
+podman kube down ./rag-milvus-ex.yaml
+```

--- a/deployments/podman-kube-play/rag-milvus-ex.yaml
+++ b/deployments/podman-kube-play/rag-milvus-ex.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rag-app-milvus
+spec:
+  containers:
+  - name: milvus-standalone
+    image: quay.io/redhat-et/milvus:standalone-rhel94
+    args: ["milvus", "run", "standalone"]
+    env:
+    - name: ETCD_DATA_DIR
+      value: /var/lib/milvus/etcd
+    - name: ETCD_USE_EMBED
+      value: true
+    - name: ETCD_CONFIG_PATH
+      value: /milvus/configs/embedEtcd.yaml
+    - name: COMMON_STORAGETYPE
+      value: local
+    volumeMounts:
+    - name: milvus-data
+      mountPath: /var/lib/milvus
+    ports:
+    - containerPort: 19530
+      hostPort: 19530
+    - containerPort: 9091
+      hostPort: 9091
+    - containerPort: 2379
+      hostPort: 2379
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 9091
+      initialDelaySeconds: 90
+      periodSeconds: 30
+      timeoutSeconds: 20
+      failureThreshold: 3
+
+  - name: rag-inference-app
+    # TODO: switch to quay.io/ai-lab once images are updated
+    image: quay.io/sallyom/rag:latest
+    ports:
+    - containerPort: 8501
+      hostPort: 8501
+    env:
+    # Adjust this as necessary
+    # See https://github.com/containers/ai-lab-recipes/tree/main/model_servers/llamacpp_python#deploy-model-service
+    # for an example of a simple llamacpp server with local model
+    - name: MODEL_ENDPOINT
+      value: http://127.0.0.1:8001
+    #- name: MODEL_ENDPOINT_BEARER
+    #  value: "xxx"
+    - name: VECTORDB_VENDOR
+      value: milvus
+    - name: VECTORDB_PORT
+      value: "19530"
+    - name: VECTORDB_HOST
+      value: "127.0.0.1"
+
+  volumes:
+  - name: milvus-data
+    hostPath:
+      # Update this if necessary
+      # /tmp/volumes/milvus must exist
+      path: /tmp/volumes/milvus
+      type: Directory

--- a/deployments/podman-kube-play/rag-milvus-ex.yaml
+++ b/deployments/podman-kube-play/rag-milvus-ex.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: milvus-standalone
-    image: quay.io/redhat-et/milvus:standalone-rhel94
+    image: quay.io/redhat-et/milvus:standalone-rhel9.5
     args: ["milvus", "run", "standalone"]
     env:
     - name: ETCD_DATA_DIR


### PR DESCRIPTION
This adds a UBI RHEL based image build. The build avoids subscription-manager requirement by installing with epel repository. Also, an example pod.yaml is added for launching RAG with Milvus standalone. 